### PR TITLE
Better handling of canting

### DIFF
--- a/pimax-openxr/instance.cpp
+++ b/pimax-openxr/instance.cpp
@@ -342,7 +342,7 @@ namespace pimax_openxr {
         }
 
         // Latch the state of parallel projection now. This is needed for computing the recommended swapchain sizes as
-        // part of xrGetSystem(). Note: we may reset this later in case the system does not use canted displays.
+        // part of xrGetSystem().
         m_useParallelProjection = !pvr_getIntConfig(m_pvrSession, "steamvr_use_native_fov", 0);
 
         m_instanceCreated = true;

--- a/pimax-openxr/mirror_window.cpp
+++ b/pimax-openxr/mirror_window.cpp
@@ -32,7 +32,7 @@ namespace pimax_openxr {
     using namespace pimax_openxr::utils;
 
     LRESULT CALLBACK wndProcWrapper(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
-        return dynamic_cast<OpenXrRuntime*>(GetInstance())->mirrorWindowProc(hwnd, msg, wParam, lParam);
+        return static_cast<OpenXrRuntime*>(GetInstance())->mirrorWindowProc(hwnd, msg, wParam, lParam);
     }
 
     void OpenXrRuntime::createMirrorWindow() {

--- a/pimax-openxr/runtime.h
+++ b/pimax-openxr/runtime.h
@@ -361,6 +361,7 @@ namespace pimax_openxr {
         std::optional<int> getSetting(const std::string& value) const;
 
         // system.cpp
+        void updateEyeInfo();
         void fillDisplayDeviceInfo();
 
         // session.cpp
@@ -474,6 +475,7 @@ namespace pimax_openxr {
         double m_frameDuration{0};
         pvrHmdInfo m_cachedHmdInfo{};
         pvrEyeRenderInfo m_cachedEyeInfo[xr::StereoView::Count]{};
+        float m_cantingAngle{0};
         float m_floorHeight{0.f};
         LARGE_INTEGER m_qpcFrequency{};
         double m_pvrTimeFromQpcTimeOffset{0};

--- a/pimax-openxr/visibility_mask.cpp
+++ b/pimax-openxr/visibility_mask.cpp
@@ -72,8 +72,8 @@ namespace pimax_openxr {
         }
 
         // We only support the hidden area mesh and we don't return a mask with parallel projection.
-        if (visibilityMaskType != XR_VISIBILITY_MASK_TYPE_HIDDEN_TRIANGLE_MESH_KHR || m_useParallelProjection) {
-            if (!m_useParallelProjection) {
+        if (visibilityMaskType != XR_VISIBILITY_MASK_TYPE_HIDDEN_TRIANGLE_MESH_KHR || m_useParallelProjection && m_cantingAngle) {
+            if (visibilityMaskType != XR_VISIBILITY_MASK_TYPE_HIDDEN_TRIANGLE_MESH_KHR) {
                 LOG_TELEMETRY_ONCE(logUnimplemented("VisibilityMaskTypeNotSupported"));
             }
 


### PR DESCRIPTION
You might want to add epsilon to cantingAngle checks but non-canted HMDs are likely to produce exactly 0 there.

Also added update for cached information that allows application to respond immediately to FoV/PP change in PiTool. Tried to make it a bit faster since pvr_getEyeRenderInfo isn't free call.