### PR TITLE
Add runtime/name field to pimax-openxr.json

### DIFF
--- a/pimax-openxr/pimax-openxr.json
+++ b/pimax-openxr/pimax-openxr.json
@@ -1,6 +1,7 @@
 {
   "file_format_version": "1.0.0",
   "runtime": {
-    "library_path": ".\\pimax-openxr.dll"
+    "library_path": ".\\pimax-openxr.dll",
+    "name": "PimaxXR"
   }
 }


### PR DESCRIPTION
This is an optional field so tools shouldn't require it, but some do (*cough* my bad)

https://registry.khronos.org/OpenXR/specs/1.0/loader.html#runtime-manifest-file-format
https://github.com/OpenKneeboard/OpenKneeboard/issues/399